### PR TITLE
Fix: Ensure ListView binds to service in widgets onUpdate

### DIFF
--- a/app/src/main/java/watson/coopgrouping/MainWidgetProvider.kt
+++ b/app/src/main/java/watson/coopgrouping/MainWidgetProvider.kt
@@ -12,11 +12,6 @@ class MainWidgetProvider : AppWidgetProvider() {
 
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         for (appWidgetId in appWidgetIds) {
-            val views = RemoteViews(context.packageName, R.layout.widget_main_layout)
-            // TODO: Set up the RemoteViewsService intent here
-            // Example:
-            // val intent = Intent(context, MainWidgetService::class.java)
-            // views.setRemoteAdapter(R.id.widget_main_listview, intent)
             val intent = Intent(context, MainWidgetService::class.java).apply {
                 // Add the app widget ID to the intent extras.
                 putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
@@ -30,7 +25,7 @@ class MainWidgetProvider : AppWidgetProvider() {
                 // Set up the RemoteViews object to use a RemoteViewsAdapter.
                 // This adapter connects to a RemoteViewsService through the specified intent.
                 // This is how you populate the data.
-                setRemoteAdapter(R.id.widget_main_listview, intent) // R.id.my_collection_view is the ID of your ListView, GridView, etc.
+                setRemoteAdapter(R.id.widget_main_listview, intent)
 
                 // The empty view is displayed when the collection has no items.
                 // It should be a sibling of the collection view.

--- a/app/src/main/java/watson/coopgrouping/SecondWidgetProvider.kt
+++ b/app/src/main/java/watson/coopgrouping/SecondWidgetProvider.kt
@@ -6,16 +6,26 @@ import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
 import watson.coopgrouping.R
+import android.net.Uri // Added import
+import android.app.PendingIntent // Added import
 
 class SecondWidgetProvider : AppWidgetProvider() {
 
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         for (appWidgetId in appWidgetIds) {
+            // Create RemoteViews for the layout
             val views = RemoteViews(context.packageName, R.layout.widget_second_layout)
-            // TODO: Set up the RemoteViewsService intent here
-            // Example:
-            // val intent = Intent(context, SecondWidgetService::class.java)
-            // views.setRemoteAdapter(R.id.widget_second_listview, intent)
+
+            // Create an Intent to launch SecondWidgetService
+            val intent = Intent(context, SecondWidgetService::class.java)
+            intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            // Set a unique data URI for the intent
+            intent.data = Uri.parse(intent.toUri(Intent.URI_INTENT_SCHEME))
+
+            // Set up the RemoteViews object to use a RemoteViewsAdapter
+            views.setRemoteAdapter(R.id.widget_second_listview, intent)
+
+            // Finally, update the widget
             appWidgetManager.updateAppWidget(appWidgetId, views)
         }
         super.onUpdate(context, appWidgetManager, appWidgetIds)


### PR DESCRIPTION
I've corrected MainWidgetProvider and SecondWidgetProvider to properly initialize and set the RemoteViewsAdapter for their ListViews within the onUpdate method.

- In SecondWidgetProvider, I implemented the missing logic to create an Intent for SecondWidgetService, add appWidgetId extra, set a unique data URI, and call setRemoteAdapter.
- In MainWidgetProvider, I reviewed and verified the existing implementation, removed redundant code and TODO comments, ensuring it correctly binds MainWidgetService.